### PR TITLE
Bug fixes and enhancements

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -112,6 +112,7 @@ final darkTheme = ThemeData(
   scaffoldBackgroundColor: Colors.black,
   textSelectionHandleColor: Color(0xFFff9f34),
   cursorColor: Colors.white,
+  textSelectionColor: Color(0xFFff9f34),
   // inputDecorationTheme: const InputDecorationTheme(fillColor: Colors.black),
 );
 
@@ -129,7 +130,8 @@ final lightTheme = ThemeData(
   dividerColor: Colors.white54,
   scaffoldBackgroundColor: const Color(0xFFE5E5E5),
   textSelectionHandleColor: Colors.blueGrey[700],
-  cursorColor: Colors.black
+  cursorColor: Colors.black,
+  textSelectionColor: Colors.blueGrey[700],
 
   //scaffoldBackgroundColor: const Color(0xFFFFFF)
 );

--- a/lib/screens/dashboard.dart
+++ b/lib/screens/dashboard.dart
@@ -183,7 +183,6 @@ class _DashboardState extends State<Dashboard> with AutomaticKeepAliveClientMixi
                       : Padding(
                           padding: const EdgeInsets.fromLTRB(0, 20, 0, 80),
                           child: FloatingActionButton.extended(
-                            splashColor: Theme.of(context).primaryColor,
                             onPressed: () {
                               Navigator.push(context, MaterialPageRoute(builder: (context) => GroupPage()));
                             },

--- a/lib/screens/dashboard.dart
+++ b/lib/screens/dashboard.dart
@@ -172,7 +172,6 @@ class _DashboardState extends State<Dashboard> with AutomaticKeepAliveClientMixi
                       ? Padding(
                           padding: const EdgeInsets.fromLTRB(0, 20, 0, 80),
                           child: FloatingActionButton(
-                            splashColor: Theme.of(context).primaryColor,
                             onPressed: () => _startCreatingTrip(context),
                             child: Tooltip(
                               message: 'Create Group',

--- a/lib/screens/groupdetailscreen/groupdetails.dart
+++ b/lib/screens/groupdetailscreen/groupdetails.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/services.dart';
 import 'package:progress_dialog/progress_dialog.dart';
+import 'package:shareacab/screens/groupscreen/group.dart';
 import 'dart:io';
 
 import 'package:shareacab/services/trips.dart';
@@ -46,6 +47,7 @@ class _GroupDetailsState extends State<GroupDetails> with AutomaticKeepAliveClie
   String end = '';
   String destination = '';
   String presentNum = '';
+  bool requestedToJoin;
 
   Timer _countdownTimer;
   @override
@@ -63,6 +65,7 @@ class _GroupDetailsState extends State<GroupDetails> with AutomaticKeepAliveClie
     return StreamBuilder(
         stream: Firestore.instance.collection('userdetails').document(currentuser.uid).snapshots(),
         builder: (context, usersnapshot) {
+          requestedToJoin = usersnapshot.data['currentGroupJoinRequests'] != null && usersnapshot.data['currentGroupJoinRequests'].contains(widget.docId);
           if (usersnapshot.connectionState == ConnectionState.active) {
             var groupUID = usersnapshot.data['currentGroup'];
             if (groupUID != null) {
@@ -272,9 +275,9 @@ class _GroupDetailsState extends State<GroupDetails> with AutomaticKeepAliveClie
                             onPressed: () async {
                               try {
                                 if (GroupDetails.inGroup) {
-                                  null;
+                                  await Navigator.push(context, MaterialPageRoute(builder: (context) => GroupPage()));
                                 } else if (privacy == 'true') {
-                                  usersnapshot.data['currentGroupJoinRequests'] != null && usersnapshot.data['currentGroupJoinRequests'].contains(widget.docId)
+                                  requestedToJoin
                                       ? null
                                       // print('already req')
                                       : await showDialog(
@@ -375,24 +378,24 @@ class _GroupDetailsState extends State<GroupDetails> with AutomaticKeepAliveClie
                             child: widget.privacy == 'true'
                                 ? GroupDetails.inGroup
                                     ? Text(
-                                        'Already in a Group',
+                                        'My Group Page', // You are in a group and viewing a private group
                                         style: TextStyle(fontSize: 20),
                                       )
-                                    : usersnapshot.data['currentGroupJoinRequests'] != null && usersnapshot.data['currentGroupJoinRequests'].contains(widget.docId)
+                                    : requestedToJoin
                                         ? Text(
-                                            'Already requested',
+                                            'Requested', // You are not in any group and requested to join
                                             style: TextStyle(fontSize: 20),
                                           )
                                         : Text(
-                                            'Request to Join',
+                                            'Request to Join', // fresh visit to private group (and user is not in any group)
                                             style: TextStyle(fontSize: 20),
                                           )
                                 : GroupDetails.inGroup
                                     ? Text(
-                                        'Already in a Group',
+                                        'My Group Page', // visiting a group page
                                         style: TextStyle(fontSize: 20),
                                       )
-                                    : Text('Join Now', style: TextStyle(fontSize: 20)),
+                                    : Text('Join Now', style: TextStyle(fontSize: 20)), // Visiting a public group page and not in any group
                             color: Theme.of(context).accentColor,
                           ),
                         ));

--- a/lib/screens/groupscreen/group.dart
+++ b/lib/screens/groupscreen/group.dart
@@ -386,6 +386,8 @@ class _GroupPageState extends State<GroupPage> with AutomaticKeepAliveClientMixi
                                                           SmoothStarRating(
                                                             rating: userRating,
                                                             filledIconData: Icons.star,
+                                                            color: Theme.of(context).accentColor,
+                                                            borderColor: Theme.of(context).accentColor,
                                                             halfFilledIconData: Icons.star_half,
                                                             defaultIconData: Icons.star_border,
                                                             starCount: 5,

--- a/lib/screens/groupscreen/group.dart
+++ b/lib/screens/groupscreen/group.dart
@@ -6,6 +6,7 @@ import 'package:shareacab/screens/chatscreen/chat_screen.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:shareacab/main.dart';
 import 'package:shareacab/screens/groupscreen/editgroup.dart';
+import 'package:shareacab/screens/notifications/services/notifservices.dart';
 import 'package:shareacab/services/trips.dart';
 import 'package:shareacab/shared/loading.dart';
 import 'package:intl/intl.dart';
@@ -19,6 +20,7 @@ class GroupPage extends StatefulWidget {
 class _GroupPageState extends State<GroupPage> with AutomaticKeepAliveClientMixin<GroupPage> {
   final RequestService _request = RequestService();
   final GlobalKey<ScaffoldState> scaffoldKey = GlobalKey<ScaffoldState>();
+  final NotifServices _notifServices = NotifServices();
 
   String groupUID = '';
   String destination = '';

--- a/lib/screens/groupscreen/group.dart
+++ b/lib/screens/groupscreen/group.dart
@@ -372,7 +372,7 @@ class _GroupPageState extends State<GroupPage> with AutomaticKeepAliveClientMixi
                                                 color: Theme.of(context).scaffoldBackgroundColor,
                                                 child: ListTile(
                                                   title: Text(snapshots.data.documents[index].data['name']),
-                                                  subtitle: Text('Hostel: ${snapshots.data.documents[index].data['hostel']}\n Mobile Number: ${snapshots.data.documents[index].data['mobilenum']}\n User Rating: ${2.5 + snapshots.data.documents[index].data['actualrating'] / 2}'),
+                                                  subtitle: Text('Hostel: ${snapshots.data.documents[index].data['hostel']}\nMobile Number: ${snapshots.data.documents[index].data['mobilenum']}\nUser Rating: ${2.5 + snapshots.data.documents[index].data['actualrating'] / 2}'),
                                                   trailing: grpOwner == snapshots.data.documents[index].documentID ? FaIcon(FontAwesomeIcons.crown) : null,
                                                   isThreeLine: true,
                                                   onTap: () {},

--- a/lib/screens/groupscreen/group.dart
+++ b/lib/screens/groupscreen/group.dart
@@ -11,6 +11,7 @@ import 'package:shareacab/services/trips.dart';
 import 'package:shareacab/shared/loading.dart';
 import 'package:intl/intl.dart';
 import 'package:progress_dialog/progress_dialog.dart';
+import 'package:smooth_star_rating/smooth_star_rating.dart';
 
 class GroupPage extends StatefulWidget {
   @override
@@ -36,6 +37,7 @@ class _GroupPageState extends State<GroupPage> with AutomaticKeepAliveClientMixi
   String end = '';
 
   int i = 0, numberOfMessages = 696;
+  double userRating;
 
   Future getMembers(String docid) async {
     var qp = await Firestore.instance.collection('group').document(docid).collection('users').getDocuments();
@@ -368,11 +370,32 @@ class _GroupPageState extends State<GroupPage> with AutomaticKeepAliveClientMixi
                                             shrinkWrap: true,
                                             itemCount: snapshots.data == null ? 0 : snapshots.data.documents.length,
                                             itemBuilder: (ctx, index) {
+                                              userRating = 2.5 + snapshots.data.documents[index].data['actualrating'] / 2;
                                               return Card(
                                                 color: Theme.of(context).scaffoldBackgroundColor,
                                                 child: ListTile(
                                                   title: Text(snapshots.data.documents[index].data['name']),
-                                                  subtitle: Text('Hostel: ${snapshots.data.documents[index].data['hostel']}\nMobile Number: ${snapshots.data.documents[index].data['mobilenum']}\nUser Rating: ${2.5 + snapshots.data.documents[index].data['actualrating'] / 2}'),
+                                                  subtitle: Column(
+                                                    crossAxisAlignment: CrossAxisAlignment.start,
+                                                    children: <Widget>[
+                                                      Text('Hostel: ${snapshots.data.documents[index].data['hostel']}'),
+                                                      Text('Mobile Number: ${snapshots.data.documents[index].data['mobilenum']}'),
+                                                      Row(
+                                                        children: <Widget>[
+                                                          Text('User Rating:'),
+                                                          SmoothStarRating(
+                                                            rating: userRating,
+                                                            filledIconData: Icons.star,
+                                                            halfFilledIconData: Icons.star_half,
+                                                            defaultIconData: Icons.star_border,
+                                                            starCount: 5,
+                                                            allowHalfRating: true,
+                                                            spacing: 2.0,
+                                                          ),
+                                                        ],
+                                                      )
+                                                    ],
+                                                  ),
                                                   trailing: grpOwner == snapshots.data.documents[index].documentID ? FaIcon(FontAwesomeIcons.crown) : null,
                                                   isThreeLine: true,
                                                   onTap: () {},

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -84,6 +84,9 @@ class _SettingsState extends State<Settings> {
               ),
             ),
             ListTile(
+              onTap: () {
+                launch('https://github.com/devclub-iitd/ShareACab/issues/new?assignees=&labels=bug&template=bug_report.md&title=Issue+Title+%40AssignedUser');
+              },
               title: Text(
                 'Bug Report',
                 style: TextStyle(fontSize: 28.0),

--- a/lib/screens/tripslist.dart
+++ b/lib/screens/tripslist.dart
@@ -123,7 +123,7 @@ class _TripsListState extends State<TripsList> {
                                               child: Container(
                                                 child: snapshot.data.documents[index].data['privacy'] == 'true'
                                                     ? Padding(
-                                                        padding: const EdgeInsets.only( right: 15.0),
+                                                        padding: const EdgeInsets.only(right: 25),
                                                         child: Icon(
                                                           Icons.lock,
                                                           color: Theme.of(context).accentColor,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -315,6 +315,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.99"
+  smooth_star_rating:
+    dependency: "direct main"
+    description:
+      name: smooth_star_rating
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.1"
   source_span:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,8 @@ dependencies:
   font_awesome_flutter: ^8.8.1
   firebase_messaging: ^6.0.16
   url_launcher: ^5.4.10
+  smooth_star_rating: 1.1.1
+
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
1. Added onTap to the list tile (for reporting bugs).


![WhatsApp Video 2020-06-30 at 10 45 39 PM](https://user-images.githubusercontent.com/52520071/86159781-6d983900-bb28-11ea-8092-ca2f17764b54.gif)


![WhatsApp Video 2020-06-30 at 10 39 38 PM](https://user-images.githubusercontent.com/52520071/86159403-eb0f7980-bb27-11ea-93eb-38519ae13059.gif)


2. Changed the Text Selection Color for both the themes.


![WhatsApp Image 2020-06-30 at 10 39 38 PM (3)](https://user-images.githubusercontent.com/52520071/86159375-de8b2100-bb27-11ea-9e2c-2bbbcc027a84.jpeg)


![WhatsApp Image 2020-06-30 at 10 39 38 PM (2)](https://user-images.githubusercontent.com/52520071/86159386-e5199880-bb27-11ea-8439-38f950672f80.jpeg)


3. Replaced text user rating with star ratings


![WhatsApp Image 2020-06-30 at 11 14 04 PM](https://user-images.githubusercontent.com/52520071/86159492-11cdb000-bb28-11ea-8e43-4961033539f8.jpeg)


![WhatsApp Image 2020-06-30 at 11 14 04 PM (1)](https://user-images.githubusercontent.com/52520071/86159509-15f9cd80-bb28-11ea-909e-015615488e39.jpeg)


4. Set the splash color of the flat button icon in the dashboard (for going to group page) as per the standards.


![WhatsApp Video 2020-06-30 at 10 41 30 PM](https://user-images.githubusercontent.com/52520071/86159689-53f6f180-bb28-11ea-826f-7b99768d826e.gif)


![WhatsApp Video 2020-06-30 at 10 41 29 PM](https://user-images.githubusercontent.com/52520071/86159708-58bba580-bb28-11ea-8402-3e610cafaf39.gif)


5. Changed the flat button icon in the group page. Earlier if you were in a group, it showed "Already in a group". Now it shows "My Group Page" and redirects to the current group page of the user. Here, attaching only the latest GIF's


![WhatsApp Video 2020-06-30 at 11 25 09 PM (1)](https://user-images.githubusercontent.com/52520071/86160360-43934680-bb29-11ea-8890-0e00c826d465.gif)


![WhatsApp Video 2020-06-30 at 11 25 09 PM](https://user-images.githubusercontent.com/52520071/86160369-48f09100-bb29-11ea-819f-d1024c0e7710.gif)

