### PR TITLE
implemented custom accent theme selection

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -22,37 +22,12 @@ Color requestPending(BuildContext context) => Colors.yellow;
 Color warning(BuildContext context) => Colors.yellow;
 Color warningHeading(BuildContext context) => Colors.red;
 
-Color getMenuItemColor(int i) {
-  switch (i) {
-    case 0:
-      {
-        return Colors.amber;
-      }
-    case 1:
-      {
-        return Colors.blue;
-      }
-    case 2:
-      {
-        return Colors.orange;
-      }
-    case 3:
-      {
-        return Colors.green;
-      }
-    case 4:
-      {
-        return Colors.purple;
-      }
-    default:
-      {
-        return Colors.amber;
-      }
+Color getVisibleColorOnScaffold(BuildContext context) {
+  if (Theme.of(context).brightness == Brightness.dark) {
+    return Colors.white;
+  } else {
+    return Colors.black;
   }
-}
-
-Color getChatBubbleTextColor() {
-  return Colors.black;
 }
 
 ThemeData getSearchAppBarTheme(BuildContext context) {
@@ -99,51 +74,19 @@ Color getBorderColorForInputFields(BuildContext context) {
   }
 }
 
-final darkTheme = ThemeData(
-  primarySwatch: Colors.grey,
-  bottomAppBarColor: const Color(0xFF212121),
-  primaryColor: const Color(0xFF212121),
-  primaryColorDark: Colors.black,
-  brightness: Brightness.dark,
-  backgroundColor: const Color(0xFF212121),
-  accentColor: Color(0xFFff9f34),
-  accentIconTheme: IconThemeData(color: Colors.black),
-  dividerColor: Colors.black12,
-  scaffoldBackgroundColor: Colors.black,
-  textSelectionHandleColor: Color(0xFFff9f34),
-  cursorColor: Colors.white,
-  textSelectionColor: Color(0xFFff9f34),
-  // inputDecorationTheme: const InputDecorationTheme(fillColor: Colors.black),
-);
-
-final lightTheme = ThemeData(
-  primarySwatch: Colors.grey,
-  bottomAppBarColor: Colors.white,
-  primaryColor: Colors.grey[600],
-  primaryColorDark: Colors.grey[800],
-  //primaryColor: Colors.white,
-  brightness: Brightness.light,
-  backgroundColor: const Color(0xFFE5E5E5),
-  accentColor: Colors.blueGrey[700],
-  //accentColor: Colors.blueGrey[700],
-  accentIconTheme: IconThemeData(color: Colors.white),
-  dividerColor: Colors.white54,
-  scaffoldBackgroundColor: const Color(0xFFE5E5E5),
-  textSelectionHandleColor: Colors.blueGrey[700],
-  cursorColor: Colors.black,
-  textSelectionColor: Colors.blueGrey[700],
-
-  //scaffoldBackgroundColor: const Color(0xFFFFFF)
-);
-
 class ThemeNotifier with ChangeNotifier {
   ThemeData _themeData;
-
-  ThemeNotifier(this._themeData);
+  bool _darkModeOn;
+  ThemeNotifier(this._themeData, this._darkModeOn);
 
   ThemeData getTheme() => _themeData;
+  bool darkModeIsOn() => _darkModeOn;
 
   void setTheme(ThemeData themeData) async {
+    await SharedPreferences.getInstance().then((prefs) {
+      _darkModeOn = !prefs.getBool('darkMode');
+      print('darkModeOn is $_darkModeOn');
+    });
     _themeData = themeData;
     notifyListeners();
   }
@@ -153,12 +96,73 @@ void main() {
   WidgetsFlutterBinding.ensureInitialized();
   SharedPreferences.getInstance().then((prefs) {
     var darkModeOn = prefs.getBool('darkMode') ?? true;
-    runApp(
-      ChangeNotifierProvider<ThemeNotifier>(
-        create: (_) => ThemeNotifier(darkModeOn ? darkTheme : lightTheme),
-        child: MyApp(),
-      ),
-    );
+    var _theme = prefs.getString('theme') ?? 'system';
+    var chosenAccentColor = prefs.getString('accentColor');
+    if (_theme == 'system') {
+      var brightness = WidgetsBinding.instance.window.platformBrightness;
+      if (brightness == Brightness.dark) {
+        darkModeOn = true;
+      } else {
+        darkModeOn = false;
+      }
+    }
+    if (chosenAccentColor == 'Blue') {
+      runApp(
+        ChangeNotifierProvider<ThemeNotifier>(
+          create: (_) => ThemeNotifier(getThemeDataForAccentColor(Colors.blue, darkModeOn), darkModeOn),
+          child: MyApp(),
+        ),
+      );
+    } else if (chosenAccentColor == 'Purple') {
+      runApp(
+        ChangeNotifierProvider<ThemeNotifier>(
+          create: (_) => ThemeNotifier(getThemeDataForAccentColor(Colors.purple, darkModeOn), darkModeOn),
+          child: MyApp(),
+        ),
+      );
+    } else if (chosenAccentColor == 'Pink') {
+      runApp(
+        ChangeNotifierProvider<ThemeNotifier>(
+          create: (_) => ThemeNotifier(getThemeDataForAccentColor(Colors.pink, darkModeOn), darkModeOn),
+          child: MyApp(),
+        ),
+      );
+    } else if (chosenAccentColor == 'Red') {
+      runApp(
+        ChangeNotifierProvider<ThemeNotifier>(
+          create: (_) => ThemeNotifier(getThemeDataForAccentColor(Colors.red, darkModeOn), darkModeOn),
+          child: MyApp(),
+        ),
+      );
+    } else if (chosenAccentColor == 'Orange') {
+      runApp(
+        ChangeNotifierProvider<ThemeNotifier>(
+          create: (_) => ThemeNotifier(getThemeDataForAccentColor(Colors.orange, darkModeOn), darkModeOn),
+          child: MyApp(),
+        ),
+      );
+    } else if (chosenAccentColor == 'Yellow') {
+      runApp(
+        ChangeNotifierProvider<ThemeNotifier>(
+          create: (_) => ThemeNotifier(getThemeDataForAccentColor(Colors.yellow, darkModeOn), darkModeOn),
+          child: MyApp(),
+        ),
+      );
+    } else if (chosenAccentColor == 'Green') {
+      runApp(
+        ChangeNotifierProvider<ThemeNotifier>(
+          create: (_) => ThemeNotifier(getThemeDataForAccentColor(Colors.green, darkModeOn), darkModeOn),
+          child: MyApp(),
+        ),
+      );
+    } else {
+      runApp(
+        ChangeNotifierProvider<ThemeNotifier>(
+          create: (_) => ThemeNotifier(getThemeDataForAccentColor(Colors.blue, darkModeOn), darkModeOn),
+          child: MyApp(),
+        ),
+      );
+    }
   });
 }
 
@@ -206,3 +210,44 @@ class MyApp extends StatelessWidget {
 //             title: title,
 //             actions: <Widget>[IconButton(icon: icon, onPressed: () {})]);
 // }
+
+ThemeData getThemeDataForAccentColor(Color accentColor, bool darkTheme) {
+  print('dark theme is $darkTheme');
+  return darkTheme
+      ? ThemeData(
+          primarySwatch: Colors.grey,
+          bottomAppBarColor: const Color(0xFF212121),
+          primaryColor: const Color(0xFF212121),
+          primaryColorDark: Colors.black,
+          brightness: Brightness.dark,
+          backgroundColor: const Color(0xFF212121),
+          accentColor: accentColor,
+          accentIconTheme: IconThemeData(color: Colors.black),
+          dividerColor: Colors.black12,
+          scaffoldBackgroundColor: Colors.black,
+          textSelectionHandleColor: Colors.blue,
+          cursorColor: Colors.white,
+          textSelectionColor: Colors.blue,
+          // inputDecorationTheme: const InputDecorationTheme(fillColor: Colors.black),
+        )
+      : ThemeData(
+          appBarTheme: AppBarTheme(color: accentColor),
+          primarySwatch: Colors.grey,
+          bottomAppBarColor: Colors.white,
+          primaryColor: Colors.grey[600],
+          primaryColorDark: Colors.grey[800],
+          //primaryColor: Colors.white,
+          brightness: Brightness.light,
+          backgroundColor: const Color(0xFFE5E5E5),
+          accentColor: accentColor,
+          //accentColor: Colors.blueGrey[700],
+          accentIconTheme: IconThemeData(color: Colors.white),
+          dividerColor: Colors.white54,
+          scaffoldBackgroundColor: const Color(0xFFE5E5E5),
+          textSelectionHandleColor: Colors.blueGrey[700],
+          cursorColor: Colors.black,
+          textSelectionColor: Colors.blueGrey[700],
+
+          //scaffoldBackgroundColor: const Color(0xFFFFFF)
+        );
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -59,11 +59,7 @@ Color getVisibleColorOnPrimaryColor(BuildContext context) {
 }
 
 Color getVisibleColorOnAccentColor(BuildContext context) {
-  if (Theme.of(context).brightness == Brightness.dark) {
-    return Colors.black;
-  } else {
-    return Colors.white;
-  }
+  return Colors.white;
 }
 
 Color getBorderColorForInputFields(BuildContext context) {
@@ -117,13 +113,6 @@ void main() {
       runApp(
         ChangeNotifierProvider<ThemeNotifier>(
           create: (_) => ThemeNotifier(getThemeDataForAccentColor(Colors.purple, darkModeOn), darkModeOn),
-          child: MyApp(),
-        ),
-      );
-    } else if (chosenAccentColor == 'Pink') {
-      runApp(
-        ChangeNotifierProvider<ThemeNotifier>(
-          create: (_) => ThemeNotifier(getThemeDataForAccentColor(Colors.pink, darkModeOn), darkModeOn),
           child: MyApp(),
         ),
       );

--- a/lib/screens/authenticate/register.dart
+++ b/lib/screens/authenticate/register.dart
@@ -259,7 +259,7 @@ class _RegisterState extends State<Register> {
                                   'REGISTER',
                                   style: TextStyle(
                                     fontSize: 20,
-                                    color: Theme.of(context).scaffoldBackgroundColor,
+                                    color: getVisibleColorOnAccentColor(context),
                                     letterSpacing: 2,
                                     fontWeight: FontWeight.w500,
                                   ),

--- a/lib/screens/authenticate/sign_in.dart
+++ b/lib/screens/authenticate/sign_in.dart
@@ -94,6 +94,7 @@ class _SignInState extends State<SignIn> {
                             child: Icon(
                               CupertinoIcons.car_detailed,
                               size: 48,
+                              color: getVisibleColorOnAccentColor(context),
                             ),
                           ),
                           SizedBox(height: 10.0),
@@ -153,7 +154,7 @@ class _SignInState extends State<SignIn> {
                                 'SIGN IN',
                                 style: TextStyle(
                                   fontSize: 20,
-                                  color: Theme.of(context).scaffoldBackgroundColor,
+                                  color: getVisibleColorOnAccentColor(context),
                                   fontWeight: FontWeight.w500,
                                   letterSpacing: 3,
                                 ),
@@ -242,7 +243,7 @@ class _SignInState extends State<SignIn> {
                                 'FORGOT PASSWORD',
                                 style: TextStyle(
                                   fontSize: 20,
-                                  color: Theme.of(context).scaffoldBackgroundColor,
+                                  color: getVisibleColorOnAccentColor(context),
                                   letterSpacing: 2,
                                   fontWeight: FontWeight.w500,
                                 ),

--- a/lib/screens/groupdetailscreen/groupdetails.dart
+++ b/lib/screens/groupdetailscreen/groupdetails.dart
@@ -379,21 +379,21 @@ class _GroupDetailsState extends State<GroupDetails> with AutomaticKeepAliveClie
                                 ? GroupDetails.inGroup
                                     ? Text(
                                         'My Group Page', // You are in a group and viewing a private group
-                                        style: TextStyle(fontSize: 20),
+                                        style: TextStyle(fontSize: 20, color: getVisibleColorOnAccentColor(context)),
                                       )
                                     : requestedToJoin
                                         ? Text(
                                             'Requested', // You are not in any group and requested to join
-                                            style: TextStyle(fontSize: 20),
+                                            style: TextStyle(fontSize: 20, color: getVisibleColorOnAccentColor(context)),
                                           )
                                         : Text(
                                             'Request to Join', // fresh visit to private group (and user is not in any group)
-                                            style: TextStyle(fontSize: 20),
+                                            style: TextStyle(fontSize: 20, color: getVisibleColorOnAccentColor(context)),
                                           )
                                 : GroupDetails.inGroup
                                     ? Text(
                                         'My Group Page', // visiting a group page
-                                        style: TextStyle(fontSize: 20),
+                                        style: TextStyle(fontSize: 20, color: getVisibleColorOnAccentColor(context)),
                                       )
                                     : Text('Join Now', style: TextStyle(fontSize: 20)), // Visiting a public group page and not in any group
                             color: Theme.of(context).accentColor,

--- a/lib/screens/notifications/widgets/notiftile.dart
+++ b/lib/screens/notifications/widgets/notiftile.dart
@@ -60,7 +60,7 @@ class _NotifTileState extends State<NotifTile> {
           subtitle: widget.purpose == 'Request to Join'
               ? widget.response == null
                   ? Container(
-                      child: Row(
+                      child: Wrap(
                         children: <Widget>[
                           FlatButton(
                             onPressed: () async {

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -300,7 +300,7 @@ class ThemeModel {
 
 class PreviewWidget extends StatefulWidget {
   @override
-  PreviewWidgetState createState() => new PreviewWidgetState();
+  PreviewWidgetState createState() => PreviewWidgetState();
 }
 
 class PreviewWidgetState extends State<PreviewWidget> {

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -57,10 +57,6 @@ class _SettingsState extends State<Settings> {
       Colors.purple,
     ),
     ColorModel(
-      'Pink',
-      Colors.pink,
-    ),
-    ColorModel(
       'Red',
       Colors.red,
     ),
@@ -179,6 +175,9 @@ class _SettingsState extends State<Settings> {
               ),
             ),
           ),
+          SizedBox(
+            height: w * 0.03,
+          ),
           ListTile(
             subtitle: Material(
               child: Padding(
@@ -251,6 +250,7 @@ class _SettingsState extends State<Settings> {
               message: 'Report Bug',
               verticalOffset: -60,
               child: IconButton(
+                padding: EdgeInsets.only(bottom: 100),
                 icon: Icon(
                   Icons.bug_report,
                   size: 40.0,

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -11,110 +11,371 @@ import 'package:firebase_auth/firebase_auth.dart';
 class Settings extends StatefulWidget {
   final AuthService _auth;
   Settings(this._auth);
+
   @override
   _SettingsState createState() => _SettingsState();
 }
 
 class _SettingsState extends State<Settings> {
-  var _darkTheme = true;
+  @override
+  void initState() {
+    SharedPreferences.getInstance().then((prefs) {
+      _darkTheme = prefs.getBool('darkMode') ?? true;
+      _theme = prefs.getString('theme') ?? 'system';
+      print(_theme);
+      _chosenAccentColor = prefs.getString('accentColor');
+      for (var i = 0; i < colorList.length; i++) {
+        if (_chosenAccentColor == colorList[i].value) {
+          _selectedIndex = i;
+          break;
+        }
+      }
+      setState(() {});
+    });
+    super.initState();
+  }
+
+  var _darkTheme;
+  Brightness brightness = WidgetsBinding.instance.window.platformBrightness;
+  var _theme;
+  String _chosenAccentColor;
+  int _selectedIndex;
   final GlobalKey<ScaffoldState> scaffoldKey = GlobalKey<ScaffoldState>();
+  var availableThemes = ['system', 'dark', 'light'];
+  List<ThemeModel> themeList = [
+    ThemeModel(label: 'Follow System', value: 'system'),
+    ThemeModel(label: 'Light', value: 'light'),
+    ThemeModel(label: 'Dark', value: 'dark'),
+  ];
+  List<ColorModel> colorList = [
+    ColorModel(
+      'Blue',
+      Colors.blue,
+    ),
+    ColorModel(
+      'Purple',
+      Colors.purple,
+    ),
+    ColorModel(
+      'Pink',
+      Colors.pink,
+    ),
+    ColorModel(
+      'Red',
+      Colors.red,
+    ),
+    ColorModel(
+      'Orange',
+      Colors.orange,
+    ),
+    ColorModel(
+      'Yellow',
+      Colors.yellow,
+    ),
+    ColorModel(
+      'Green',
+      Colors.green,
+    ),
+  ];
+  double w, h;
 
   @override
   Widget build(BuildContext context) {
-    final themeNotifier = Provider.of<ThemeNotifier>(context);
     final user = Provider.of<FirebaseUser>(context);
-    _darkTheme = (themeNotifier.getTheme() == darkTheme);
+    w = MediaQuery.of(context).size.width;
+    h = MediaQuery.of(context).size.height;
+    final themeNotifier = Provider.of<ThemeNotifier>(context);
+
     return Scaffold(
-        appBar: AppBar(
-          title: Text('Settings'),
-          actions: <Widget>[
-            user != null
-                ? FlatButton.icon(
-                    textColor: getVisibleColorOnPrimaryColor(context),
-                    icon: Icon(FontAwesomeIcons.signOutAlt),
-                    onPressed: () async {
-                      ProgressDialog pr;
-                      pr = ProgressDialog(context, type: ProgressDialogType.Normal, isDismissible: false, showLogs: false);
-                      pr.style(
-                        message: 'Logging out...',
-                        backgroundColor: Theme.of(context).backgroundColor,
-                        messageTextStyle: TextStyle(color: Theme.of(context).accentColor),
-                      );
-                      await pr.show();
-                      await Future.delayed(Duration(seconds: 1)); // sudden logout will show ProgressDialog for a very short time making it not very nice to see :p
-                      try {
-                        await widget._auth.signOut();
-                        await pr.hide();
-                        Navigator.pop(context);
-                      } catch (err) {
-                        // show e.message
-                        await pr.hide();
-                        String errStr = err.message ?? err.toString();
-                        final snackBar = SnackBar(content: Text(errStr), duration: Duration(seconds: 3));
-                        scaffoldKey.currentState.showSnackBar(snackBar);
-                      }
-                    },
-                    label: Text('Logout'),
-                  )
-                : FlatButton(onPressed: null, child: null)
-          ],
-        ),
-        body: ListView(
-          children: <Widget>[
-            SizedBox(height: 10.0),
-            ListTile(
-              title: Text(
-                'Dark Mode',
-                style: TextStyle(fontSize: 28.0),
-              ),
-              contentPadding: EdgeInsets.all(26.0),
-              subtitle: _darkTheme ? Text('Swipe to disable dark mode') : Text('Swipe to enable dark mode'),
-              trailing: Transform.scale(
-                scale: 1.6,
-                child: Switch(
-                  activeColor: Theme.of(context).accentColor,
-                  value: _darkTheme,
-                  onChanged: (val) {
-                    setState(() {
-                      _darkTheme = val;
-                    });
-                    onThemeChanged(val, themeNotifier);
+      appBar: AppBar(
+        title: Text('Settings'),
+        actions: <Widget>[
+          user != null
+              ? FlatButton.icon(
+                  textColor: getVisibleColorOnPrimaryColor(context),
+                  icon: Icon(FontAwesomeIcons.signOutAlt),
+                  onPressed: () async {
+                    ProgressDialog pr;
+                    pr = ProgressDialog(context, type: ProgressDialogType.Normal, isDismissible: false, showLogs: false);
+                    pr.style(
+                      message: 'Logging out...',
+                      backgroundColor: Theme.of(context).backgroundColor,
+                      messageTextStyle: TextStyle(color: Theme.of(context).accentColor),
+                    );
+                    await pr.show();
+                    await Future.delayed(Duration(seconds: 1)); // sudden logout will show ProgressDialog for a very short time making it not very nice to see :p
+                    try {
+                      await widget._auth.signOut();
+                      await pr.hide();
+                      Navigator.pop(context);
+                    } catch (err) {
+                      // show e.message
+                      await pr.hide();
+                      String errStr = err.message ?? err.toString();
+                      final snackBar = SnackBar(content: Text(errStr), duration: Duration(seconds: 3));
+                      scaffoldKey.currentState.showSnackBar(snackBar);
+                    }
                   },
+                  label: Text('Logout'),
+                )
+              : FlatButton(onPressed: null, child: null)
+        ],
+      ),
+      body: ListView(
+        children: <Widget>[
+          PreviewWidget(),
+          ListTile(
+            subtitle: Material(
+              child: Padding(
+                padding: const EdgeInsets.all(10.0),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: <Widget>[
+                    Text(
+                      'App Theme',
+                      style: TextStyle(
+                        fontSize: 18,
+                        color: getVisibleColorOnScaffold(context),
+                        fontWeight: FontWeight.w400,
+                      ),
+                    ),
+                    DropdownButton<String>(
+                      icon: Icon(
+                        Icons.arrow_drop_down,
+                        color: Theme.of(context).accentColor,
+                      ),
+                      iconSize: 30,
+                      style: TextStyle(color: getVisibleColorOnScaffold(context), fontSize: 15),
+                      underline: Container(
+                        height: 2,
+                        color: Theme.of(context).accentColor,
+                      ),
+                      items: List.generate(themeList.length, (index) {
+                        return DropdownMenuItem<String>(
+                          value: themeList[index].value,
+                          child: Text(
+                            themeList[index].label,
+                          ),
+                        );
+                      }),
+                      onChanged: (String newValueSelected) {
+                        newValueSelected != 'system'
+                            ? setState(() {
+                                _theme = newValueSelected;
+                                _darkTheme = newValueSelected == 'dark' ? true : false;
+                                newValueSelected == 'dark' ? onThemeChanged(true, themeNotifier) : onThemeChanged(false, themeNotifier);
+                              })
+                            : setState(() {
+                                _theme = newValueSelected;
+                                brightness == Brightness.dark ? _darkTheme = true : _darkTheme = false;
+                                brightness == Brightness.dark ? onThemeChanged(true, themeNotifier) : onThemeChanged(false, themeNotifier);
+                              });
+                        setTheme(newValueSelected);
+                      },
+                      value: _theme,
+                    ),
+                  ],
                 ),
               ),
             ),
-            ListTile(
-              onTap: () {
-                launch('https://github.com/devclub-iitd/ShareACab/issues/new?assignees=&labels=bug&template=bug_report.md&title=Issue+Title+%40AssignedUser');
-              },
-              title: Text(
-                'Bug Report',
-                style: TextStyle(fontSize: 28.0),
-              ),
-              contentPadding: EdgeInsets.all(26.0),
-              subtitle: Text('Found a bug, report here:'),
-              trailing: Tooltip(
-                message: 'Report Bug',
-                verticalOffset: -60,
-                child: IconButton(
-                  icon: Icon(
-                    Icons.bug_report,
-                    size: 40.0,
-                    color: Theme.of(context).accentColor,
-                  ),
-                  onPressed: () {
-                    launch('https://github.com/devclub-iitd/ShareACab/issues/new?assignees=&labels=bug&template=bug_report.md&title=Issue+Title+%40AssignedUser');
-                  },
+          ),
+          ListTile(
+            subtitle: Material(
+              child: Padding(
+                padding: const EdgeInsets.all(10.0),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 8.0),
+                      child: Text(
+                        'Choose accent color',
+                        style: TextStyle(
+                          fontSize: 18,
+                          color: getVisibleColorOnScaffold(context),
+                          fontWeight: FontWeight.w400,
+                        ),
+                      ),
+                    ),
+                    Container(
+                      padding: EdgeInsets.symmetric(vertical: 10),
+                      child: SingleChildScrollView(
+                        scrollDirection: Axis.horizontal,
+                        child: Row(
+                          children: List.generate(colorList.length, (index) {
+                            return SizedBox(
+                              width: w * 0.20,
+                              height: w * 0.10,
+                              child: GestureDetector(
+                                  child: AnimatedContainer(
+                                    margin: const EdgeInsets.symmetric(horizontal: 3),
+                                    child: _selectedIndex == index
+                                        ? Icon(
+                                            Icons.check,
+                                            color: Colors.white,
+                                          )
+                                        : null,
+                                    decoration: BoxDecoration(
+                                      color: colorList[index].color,
+                                      borderRadius: BorderRadius.circular(_selectedIndex == index ? w * 0.05 : 0),
+                                    ),
+                                    duration: Duration(milliseconds: 300),
+                                  ),
+                                  onTap: () {
+                                    setState(() {
+                                      _selectedIndex = index;
+                                    });
+                                    onColorChanged(colorList[index].value, colorList[index].color, themeNotifier);
+                                  }),
+                            );
+                          }),
+                        ),
+                      ),
+                    ),
+                  ],
                 ),
               ),
             ),
-          ],
-        ));
+          ),
+          ListTile(
+            onTap: () {
+              launch('https://github.com/devclub-iitd/ShareACab/issues/new?assignees=&labels=bug&template=bug_report.md&title=Issue+Title+%40AssignedUser');
+            },
+            title: Text(
+              'Bug Report',
+              style: TextStyle(fontSize: 28.0),
+            ),
+            contentPadding: EdgeInsets.all(26.0),
+            subtitle: Text('Found a bug, report here:'),
+            trailing: Tooltip(
+              message: 'Report Bug',
+              verticalOffset: -60,
+              child: IconButton(
+                icon: Icon(
+                  Icons.bug_report,
+                  size: 40.0,
+                  color: Theme.of(context).accentColor,
+                ),
+                onPressed: () {
+                  launch('https://github.com/devclub-iitd/ShareACab/issues/new?assignees=&labels=bug&template=bug_report.md&title=Issue+Title+%40AssignedUser');
+                },
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
   }
 
   void onThemeChanged(bool value, ThemeNotifier themeNotifier) async {
-    (value) ? themeNotifier.setTheme(darkTheme) : themeNotifier.setTheme(lightTheme);
+    themeNotifier.setTheme(getThemeDataForAccentColor(Theme.of(context).accentColor, value));
     var prefs = await SharedPreferences.getInstance();
     await prefs.setBool('darkMode', value);
+  }
+
+  void onColorChanged(String value, Color accentColor, ThemeNotifier themeNotifier) async {
+    themeNotifier.setTheme(getThemeDataForAccentColor(accentColor, _darkTheme));
+    var prefs = await SharedPreferences.getInstance();
+    await prefs.setString('accentColor', value);
+  }
+
+  void setTheme(String theme) async {
+    var prefs = await SharedPreferences.getInstance();
+    await prefs.setString('theme', theme);
+  }
+}
+
+class ColorModel {
+  String value;
+  Color color;
+
+  ColorModel(this.value, this.color);
+}
+
+class ThemeModel {
+  String value, label;
+
+  ThemeModel({this.value, this.label});
+}
+
+class PreviewWidget extends StatefulWidget {
+  @override
+  PreviewWidgetState createState() => new PreviewWidgetState();
+}
+
+class PreviewWidgetState extends State<PreviewWidget> {
+  bool switchValue = true, checkBoxValue = true;
+  double sliderValue = 0.5;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      child: Material(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: Text(
+                'Preview',
+                style: TextStyle(
+                  fontSize: 18,
+                  color: getVisibleColorOnScaffold(context),
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+            ),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceAround,
+              children: <Widget>[
+                Switch(
+                    activeColor: Theme.of(context).accentColor,
+                    value: switchValue,
+                    onChanged: (_) {
+                      setState(() {
+                        switchValue = !switchValue;
+                      });
+                    }),
+                Radio(
+                  activeColor: Theme.of(context).accentColor,
+                  groupValue: 0,
+                  value: 0,
+                  onChanged: (_) {},
+                ),
+                Checkbox(
+                  activeColor: Theme.of(context).accentColor,
+                  value: checkBoxValue,
+                  onChanged: (_) {
+                    setState(() {
+                      checkBoxValue = !checkBoxValue;
+                    });
+                  },
+                ),
+                RaisedButton(
+                  color: Theme.of(context).accentColor,
+                  child: Text(
+                    'BUTTON',
+                    style: TextStyle(color: getVisibleColorOnAccentColor(context)),
+                  ),
+                  onPressed: () {},
+                )
+              ],
+            ),
+            Slider(
+              activeColor: Theme.of(context).accentColor,
+              onChanged: (double newValue) {
+                setState(() {
+                  sliderValue = newValue;
+                });
+              },
+              min: 0,
+              max: 1,
+              value: sliderValue,
+            ),
+          ],
+        ),
+      ),
+    );
   }
 }


### PR DESCRIPTION
1. Implemented custom accent theme selection from settings. Showed a palette for various colors.
2. Available theme selection are: `light`, `dark` and `follow system`. Follow system will adapt the mobile theme (dark or light). Note that if we change the theme of mobile while `follow system` is chosen, it would automatically adapt to the change.
3. Unfortunately, #91 is still there. However, effect is almost negligible. It is slightly significant if someone choose two completely different colors. Good thing is that it is gone when someone switch between themes (because color remains same).
This is how the app looks in various themes:


![WhatsApp Video 2020-07-13 at 12 51 33 AM](https://user-images.githubusercontent.com/52520071/87254940-315bc580-c4a4-11ea-9d50-6c45a3bbed90.gif)
